### PR TITLE
Add Composer Optimizations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "symfony/yaml": "v3.4.35",
         "twig/twig": "v1.42.3",
         "typo3/phar-stream-wrapper": "v3.1.3",
+        "zaporylie/composer-drupal-optimizations": "1.1.1",
         "zendframework/zend-diactoros": "1.8.7",
         "zendframework/zend-escaper": "2.6.1",
         "zendframework/zend-feed": "2.12.0",


### PR DESCRIPTION
Add composer optimizations provided by zaporylie/composer-drupal-optimizations

Without this composer commands like `composer update` or `composer require` may fail due to memory limitations.

See https://github.com/zaporylie/composer-drupal-optimizations