### PR TITLE
Update pear/archive_tar to 1.4.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "laminas/laminas-stdlib": "3.2.1",
         "laminas/laminas-zendframework-bridge": "1.0.4",
         "masterminds/html5": "2.7.0",
-        "pear/archive_tar": "1.4.11",
+        "pear/archive_tar": "1.4.12",
         "pear/console_getopt": "v1.4.3",
         "pear/pear-core-minimal": "v1.10.10",
         "pear/pear_exception": "v1.0.1",


### PR DESCRIPTION
package pear/archive_tar having security vulnerability which fails `blt tests:security-composer`
[CVE-2020-36193][]: Allows write operations with Directory Traversal due to inadequate checking of symbolic links